### PR TITLE
Nova regra

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Os eventos serão divulgados nas redes sociais do DevParaná, assim como incluso
 
 ## Regras
 
-- Pelo menos 1 evento por mês;
+- Pelo menos 5 eventos por ano;
 - Mínimo de 6 palestrantes nos últimos 6 meses (não queremos patrocinar cursos, e sim fazer com que as comunidades sejam estimuladas);
 - Quando enviada alguma verba para realização de eventos, a mesma deve ser utilizada exclusivamente para o coffee, caso tenha alguma sobra deste valor o mesmo deve ser devolvido;
 - Qualquer verba destinada para realização de eventos provenientes deste programa não pode ser destinada a comprar bebidas alcoólicas;

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Os eventos serão divulgados nas redes sociais do DevParaná, assim como incluso
 - React Maringá [meetup.com/pt-BR/React-Maringa/](https://www.meetup.com/pt-BR/React-Maringa/)
 - GDG Toledo [meetup.com/pt-BR/GDG-Toledo-PR/](https://www.meetup.com/pt-BR/GDG-Toledo-PR/)
 - Maringá Agile [meetup.com/pt-BR/developerparana/](https://www.meetup.com/pt-BR/developerparana/)
-- IxDA Maringá [meetup.com/pt-BR/IxDAMaringa/](https://www.meetup.com/IxDAMaringa/)
 
 
 ## Como participar

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Os eventos serão divulgados nas redes sociais do DevParaná, assim como incluso
 - React Maringá [meetup.com/pt-BR/React-Maringa/](https://www.meetup.com/pt-BR/React-Maringa/)
 - GDG Toledo [meetup.com/pt-BR/GDG-Toledo-PR/](https://www.meetup.com/pt-BR/GDG-Toledo-PR/)
 - Maringá Agile [meetup.com/pt-BR/developerparana/](https://www.meetup.com/pt-BR/developerparana/)
+- IxDA Maringá [meetup.com/pt-BR/IxDAMaringa/](https://www.meetup.com/IxDAMaringa/)
 
 
 ## Como participar


### PR DESCRIPTION
De acordo com nossas conversas em reuniões, estou enviando esse PR para sugerir a mudança da regra de periodicidade dos eventos afiliados, principalmente pelo aumento da quantidade de afiliados em Maringá-PR, essa regra de 1 evento por mês já não está de acordo com a realidade dos nossos grupos.

A sugestão foi para a mudança de **5 eventos por ano** como uma das regras de frequência na realização de eventos de grupos afiliados.